### PR TITLE
Add test my1 light effect

### DIFF
--- a/esphome/components/light/effects.py
+++ b/esphome/components/light/effects.py
@@ -48,7 +48,6 @@ from .types import (
     AddressableColorWipeEffect,
     AddressableColorWipeEffectColor,
     AddressableScanEffect,
-    AddressableMy1Effect,
     AddressableTwinkleEffect,
     AddressableRandomTwinkleEffect,
     AddressableFireworksEffect,
@@ -62,9 +61,6 @@ CONF_REVERSE = "reverse"
 CONF_GRADIENT = "gradient"
 CONF_MOVE_INTERVAL = "move_interval"
 CONF_SCAN_WIDTH = "scan_width"
-CONF_MY1_MOVE_INTERVAL = "my1_move_interval"
-CONF_MY1_WIDTH = "my1_scan_width"
-CONF_MY1_BLOCK_WIDTH = "block_width"
 CONF_TWINKLE_PROBABILITY = "twinkle_probability"
 CONF_PROGRESS_INTERVAL = "progress_interval"
 CONF_SPARK_PROBABILITY = "spark_probability"
@@ -76,7 +72,6 @@ CONF_ADDRESSABLE_LAMBDA = "addressable_lambda"
 CONF_ADDRESSABLE_RAINBOW = "addressable_rainbow"
 CONF_ADDRESSABLE_COLOR_WIPE = "addressable_color_wipe"
 CONF_ADDRESSABLE_SCAN = "addressable_scan"
-CONF_ADDRESSABLE_MY1 = "addressable_my1"
 CONF_ADDRESSABLE_TWINKLE = "addressable_twinkle"
 CONF_ADDRESSABLE_RANDOM_TWINKLE = "addressable_random_twinkle"
 CONF_ADDRESSABLE_FIREWORKS = "addressable_fireworks"
@@ -439,6 +434,13 @@ async def addressable_scan_effect_to_code(config, effect_id):
     cg.add(var.set_move_interval(config[CONF_MOVE_INTERVAL]))
     cg.add(var.set_scan_width(config[CONF_SCAN_WIDTH]))
     return var
+
+from .types import AddressableMy1Effect
+
+CONF_MY1_MOVE_INTERVAL = "my1_move_interval"
+CONF_MY1_WIDTH = "my1_scan_width"
+CONF_MY1_BLOCK_WIDTH = "block_width"
+CONF_ADDRESSABLE_MY1 = "addressable_my1"
 
 @register_addressable_effect(
     "addressable_my1",


### PR DESCRIPTION
# What does this implement/fix?

Add effect "my1" to light component  based on scan effect

## Types of changes

- [*] New feature (non-breaking change which adds functionality)

## Test Environment

- [*] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
light:
  - platform: esp32_rmt_led_strip
    rgb_order: GRB
    pin: 21
    num_leds: 100
    rmt_channel: 0
    chipset: SK6812
    name: "My Light"
    effects:
      - addressable_my1:
          name: Scan Effect my1s
          my1_move_interval: 32ms
          my1_scan_width: 1
          block_width: 6


```yaml
# Example config.yaml

```

## Checklist:
  - [*] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
